### PR TITLE
Add universal module definition pattern to be able to use the library with requirejs etc

### DIFF
--- a/jquery.ui.sortable-animation.js
+++ b/jquery.ui.sortable-animation.js
@@ -7,6 +7,19 @@
  * Depends:
  *  jquery.ui.sortable.js
  */
+ 
+(function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define([ "jquery", "jquery-ui" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery );
+	}
+}(function( $ ) {
+  
 (function (window, $) {
   var supports = {},
       testProp = function (prefixes) {
@@ -122,3 +135,5 @@
     }
   });   
 })(window, jQuery);
+
+}));


### PR DESCRIPTION
Hello,

I've added the universal module definition pattern to be able to use your library with requirejs and any other module loader if used.

Sebastien